### PR TITLE
Add calendar to project page (Project deadline & Inline step due date…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,16 +12,11 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route element={<MainLayout />}>
-          {/* индекс = "/" */}
-          <Route index element={<HomePage />} />
-
-          {/* остальные страницы */}
-          <Route path="login" element={<LoginPage />} />
-          <Route path="signup" element={<SignUpForm />} />
-          <Route path="project" element={<ProjectPage />} />
-          <Route path="step/:id" element={<StepPage />} />
-
-          {/* fallback */}
+          <Route path="/" element={<HomePage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignUpForm />} />
+          <Route path="/project" element={<ProjectPage />} />
+          <Route path="/step/:id" element={<StepPage />} />
           <Route path="*" element={<div>Not Found</div>} />
         </Route>
       </Routes>

--- a/src/components/DueBanner.jsx
+++ b/src/components/DueBanner.jsx
@@ -1,0 +1,14 @@
+export default function DueBanner({
+  dueInfo,
+  text = "less than 24 hours to the deadline",
+}) {
+  if (!dueInfo?.dueSoon) return null;
+  return (
+    <div className="mb-4 rounded-md border border-red-300 bg-orange-50 text-orange-900 text-xs px-3 py-2">
+      <span className="font-semibold">Reminder:</span> {text}
+      {typeof dueInfo.hoursLeft === "number"
+        ? ` (${dueInfo.hoursLeft}h left)`
+        : ""}
+    </div>
+  );
+}

--- a/src/pages/ProjectPage.jsx
+++ b/src/pages/ProjectPage.jsx
@@ -1,68 +1,43 @@
-// src/pages/ProjectPage.jsx
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 
-// UI
 import Badge from "../components/Badge";
 import ProgressBar from "../components/ProgressBar";
+import DueBanner from "../components/DueBanner";
 
-// --- Local storage helpers ---
-const STORAGE_KEY = "steps_v1";
-const load = () => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
+import { toDateOnly, getDueInfo } from "../utils/due";
+import { derive, toVariant } from "../utils/derive";
+import { createJSONStore } from "../utils/storage";
+
+// --- storage stores ---
+const stepsStore = createJSONStore("steps_v1", [], {
+  migrate: (arr) =>
+    (arr || []).map((s) => ({ ...s, dueDate: toDateOnly(s.dueDate) })),
+});
+
+const projectStore = createJSONStore(
+  "project_meta_v1",
+  { description: "", dueDate: null },
+  {
+    migrate: (p = {}) => ({
+      description: p.description || "",
+      dueDate: toDateOnly(p.dueDate),
+    }),
   }
-};
-const save = (steps) =>
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(steps));
-
-// --- Calculate progress & status from subtasks ---
-function derive(step) {
-  const total = step?.subtasks?.length || 0;
-  const done = step?.subtasks?.filter((t) => t.done).length || 0;
-  const progress = total ? Math.round((done / total) * 100) : 0;
-
-  let status = "Not Started";
-  const overdue =
-    step?.dueDate && new Date(step.dueDate) < new Date() && done < total;
-  if (overdue) status = "Overdue";
-  else if (done === 0) status = "Not Started";
-  else if (done === total) status = "Completed";
-  else status = "In Progress";
-
-  return { progress, status, total, done };
-}
-
-// Map domain statuses -> UI variants used by Badge/ProgressBar
-const toVariant = (status) => {
-  switch (status) {
-    case "Completed":
-      return "success";
-    case "In Progress":
-      return "warning";
-    case "Overdue":
-      return "error";
-    case "Not Started":
-    default:
-      return "neutral";
-  }
-};
+);
 
 export default function ProjectPage() {
-  const [description, setDescription] = useState("");
-  const [steps, setSteps] = useState(() => {
-    const fromLS = load();
-    if (fromLS) return fromLS;
+  // Steps (with seeding if empty)
+  const initialSteps = (() => {
+    const fromLS = stepsStore.load();
+    if (fromLS && fromLS.length) return fromLS;
 
     const seed = [
       {
         id: 1,
         title: "Define scope",
         description: "Agree on goals and constraints.",
-        dueDate: null,
+        dueDate: null, // 'YYYY-MM-DD'
         subtasks: [
           { id: 1, title: "Write brief", done: true },
           { id: 2, title: "Approve goals", done: true },
@@ -97,34 +72,79 @@ export default function ProjectPage() {
         ],
       },
     ];
-    save(seed);
+    stepsStore.save(seed);
     return seed;
-  });
+  })();
 
+  const [steps, setSteps] = useState(initialSteps);
+
+  // Project meta
+  const initialProject = projectStore.load();
+  const [description, setDescription] = useState(initialProject.description);
+  const [projectDue, setProjectDue] = useState(initialProject.dueDate); // 'YYYY-MM-DD' or null
+
+  // Persist
   useEffect(() => {
-    save(steps);
+    stepsStore.save(steps);
   }, [steps]);
+  useEffect(() => {
+    projectStore.save({ description, dueDate: projectDue });
+  }, [description, projectDue]);
 
+  // Actions
   const addStep = () => {
     const nextId = steps.length ? Math.max(...steps.map((s) => s.id)) + 1 : 1;
-    const newStep = {
-      id: nextId,
-      title: `New Step ${nextId}`,
-      description: "",
-      dueDate: null,
-      subtasks: [],
-    };
-    const updated = [...steps, newStep];
-    setSteps(updated);
-    save(updated);
+    setSteps([
+      ...steps,
+      {
+        id: nextId,
+        title: `New Step ${nextId}`,
+        description: "",
+        dueDate: null,
+        subtasks: [],
+      },
+    ]);
   };
+
+  const setStepDueDate = (stepId, value) => {
+    setSteps(
+      steps.map((s) => (s.id === stepId ? { ...s, dueDate: value || null } : s))
+    );
+  };
+
+  // Project deadline flags
+  const projectDueInfo = useMemo(() => {
+    const allDone = steps.every((s) => derive(s).progress === 100);
+    return getDueInfo(projectDue, allDone);
+  }, [projectDue, steps]);
+
+  const projectOverdue = projectDueInfo.overdue;
 
   return (
     <div className="max-w-2xl mx-auto p-4 bg-gray-50 border border-gray-200 rounded-xl shadow-sm">
       {/* Header */}
-      <div className="flex justify-between items-center border-b border-gray-200 pb-3 mb-4">
+      <div className="flex items-center border-b border-gray-200 pb-3 mb-2 gap-3">
         <h1 className="text-2xl font-bold">Project</h1>
+        <div className="ml-auto flex items-center gap-2">
+          <label htmlFor="project-due" className="text-xs text-gray-500">
+            Project due
+          </label>
+          <input
+            id="project-due"
+            type="date"
+            value={projectDue || ""}
+            onChange={(e) => setProjectDue(e.target.value || null)} // store as 'YYYY-MM-DD'
+            className="border border-gray-300 rounded px-2 py-1 text-xs"
+          />
+          {projectOverdue && <Badge status="error">Overdue</Badge>}
+        </div>
       </div>
+
+      {/* <24h project warning */}
+      <DueBanner
+        dueInfo={projectDueInfo}
+        text="less than 24 hours to the project deadline"
+      />
 
       {/* Project description */}
       <label
@@ -167,6 +187,27 @@ export default function ProjectPage() {
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1">
                   <div className="text-sm font-medium">{s.title}</div>
+
+                  {/* Inline due date for step */}
+                  <div className="mt-2 flex items-center gap-2">
+                    <label
+                      className="text-xs text-gray-500"
+                      htmlFor={`due-${s.id}`}
+                    >
+                      Due date
+                    </label>
+                    <input
+                      id={`due-${s.id}`}
+                      type="date"
+                      value={s.dueDate || ""}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) => {
+                        e.stopPropagation();
+                        setStepDueDate(s.id, e.target.value);
+                      }}
+                      className="border border-gray-300 rounded px-2 py-1 text-xs"
+                    />
+                  </div>
 
                   {/* Progress bar */}
                   <div className="mt-3">

--- a/src/utils/derive.js
+++ b/src/utils/derive.js
@@ -1,0 +1,34 @@
+import { getDueInfo } from "./due";
+
+// Progress/status of a step based on its subtasks and deadline
+export function derive(step) {
+  const total = step?.subtasks?.length || 0;
+  const done = step?.subtasks?.filter((t) => t.done).length || 0;
+  const progress = total ? Math.round((done / total) * 100) : 0;
+
+  const overdue = step?.dueDate
+    ? getDueInfo(step.dueDate, done === total).overdue
+    : false;
+
+  let status = "Not Started";
+  if (overdue) status = "Overdue";
+  else if (done === 0) status = "Not Started";
+  else if (done === total) status = "Completed";
+  else status = "In Progress";
+
+  return { progress, status, total, done };
+}
+
+// Map domain statuses to UI variants
+export function toVariant(status) {
+  switch (status) {
+    case "Completed":
+      return "success";
+    case "In Progress":
+      return "warning";
+    case "Overdue":
+      return "error";
+    default:
+      return "neutral";
+  }
+}

--- a/src/utils/due.js
+++ b/src/utils/due.js
@@ -1,0 +1,35 @@
+export const HOUR = 36e5; // milliseconds in one hour
+export const DAY = 24 * HOUR; // milliseconds in one day
+
+// Normalize input date to a 'YYYY-MM-DD' date-only string
+export function toDateOnly(d) {
+  if (!d) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
+  const dt = new Date(d);
+  const y = dt.getFullYear();
+  const m = String(dt.getMonth() + 1).padStart(2, "0");
+  const day = String(dt.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// End of the local day (23:59:59.999) for 'YYYY-MM-DD' → epoch ms
+export function endOfLocalDayMs(dateStr) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d, 23, 59, 59, 999).getTime();
+}
+
+// Return deadline flags:
+// - overdue: deadline has passed
+// - dueSoon: less than 24 hours remaining
+// - hoursLeft: hours remaining (rounded up)
+export function getDueInfo(due, completed = false) {
+  if (!due || completed)
+    return { overdue: false, dueSoon: false, hoursLeft: null };
+  const delta = endOfLocalDayMs(due) - Date.now();
+  if (delta <= 0) return { overdue: true, dueSoon: false, hoursLeft: 0 };
+  return {
+    overdue: false,
+    dueSoon: delta <= DAY,
+    hoursLeft: Math.ceil(delta / HOUR),
+  };
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,24 @@
+export function createJSONStore(key, defaultValue, { migrate } = {}) {
+  const runMigrate = typeof migrate === "function" ? migrate : (x) => x;
+
+  function load() {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return defaultValue;
+      const parsed = JSON.parse(raw);
+      return runMigrate(parsed);
+    } catch {
+      return defaultValue;
+    }
+  }
+
+  function save(value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+
+  function reset() {
+    localStorage.removeItem(key);
+  }
+
+  return { load, save, reset };
+}


### PR DESCRIPTION
**Add calendar to project page (Project deadline & Inline step due date editors) + Overdue badge & warning via DueBanner**


•	Project deadline in ProjectPage header (YYYY-MM-DD) + Overdue badge.
•	“<24h” warning via DueBanner (orange box with red border) — shown on both StepPage and ProjectPage, with hoursLeft.
•	Inline step due date editors on ProjectPage (<input type="date">); click uses stopPropagation to avoid navigation.
•	Robust date handling: store date-only YYYY-MM-DD; compute deadline as end of local day; removed toISOString to avoid timezone shifts.
•	Shared utilities:
•	src/utils/due.js — toDateOnly, endOfLocalDayMs, getDueInfo, HOUR/DAY.
•	src/utils/derive.js — derive(step), toVariant(status).
•	src/utils/storage.js — createJSONStore (generic load/save/reset + migrations).
•	Component: src/components/DueBanner.jsx (universal “<24h” banner).
•	Storage: moved steps_v1 and project_meta_v1 to createJSONStore, with migration from old ISO dates to YYYY-MM-DD.
•	StepPage: normalize stateStep.dueDate, show “<24h” banner, save due date as YYYY-MM-DD, shared updateAndPersist.
•	ProjectPage: project deadline + “<24h” banner, persist project description/date, seed steps when storage is empty.
